### PR TITLE
Update VSCode settings for formatting and file associations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,31 +11,35 @@
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,
 	"editor.tabSize": 4,
-	"[markdown]":
-	{
+	"[markdown]": {
 		"editor.insertSpaces": true,
 		"files.trimTrailingWhitespace": false
 	},
-	"[python]":
-	{
+	"[html]": {
+		"editor.formatOnSave": true
+	},
+	"[css][scss]": {
+		"editor.formatOnSave": true
+	},
+	"[javascript][typescript]": {
+		"editor.formatOnSave": true
+	},
+	"[python]": {
 		"editor.defaultFormatter": "ms-python.black-formatter",
 		"editor.formatOnSave": true,
 		"editor.insertSpaces": true
 	},
-	"[yml]":
-	{
+	"[yml][yaml]": {
 		"editor.formatOnSave": true,
 		"editor.insertSpaces": true,
 		"editor.tabSize": 2
 	},
-	"[json]":
-	{
+	"[json][jsonc]": {
 		"editor.formatOnSave": true
 	},
 	"files.eol": "\n",
 	"files.trimTrailingWhitespace": true,
-	"files.associations":
-	{
+	"files.associations": {
 		"*.env": "dotenv",
 		"*.env.*": "dotenv",
 		"*.json": "jsonc",
@@ -47,8 +51,7 @@
 		".dockerignore": "ignore",
 		".gitignore": "ignore"
 	},
-	"files.watcherExclude":
-	{
+	"files.watcherExclude": {
 		"**/.git/**": true,
 		"**/.git/objects/**": true,
 		"**/.git/subtree-cache/**": true,
@@ -82,8 +85,7 @@
 		"**/.DS_Store": true,
 		"**/Thumbs.db": true
 	},
-	"files.exclude":
-	{
+	"files.exclude": {
 		"**/.git": false,
 		"**/.svn": false,
 		"**/.hg": false,
@@ -93,8 +95,7 @@
 	},
 	"search.useIgnoreFiles": false,
 	"search.showLineNumbers": true,
-	"search.exclude":
-	{
+	"search.exclude": {
 		"**/.git": true,
 		"**/.svn": true,
 		"**/.hg": true,


### PR DESCRIPTION
This pull request updates the VSCode settings for formatting and file associations. It includes changes to the settings for markdown, html, css, scss, javascript, typescript, python, yml, yaml, json, and jsonc files. The changes ensure consistent formatting and enable automatic formatting on save for these file types.