### PR TITLE
:hammer: Add --root-user-action ignore to pip install commands in doc…

### DIFF
--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -131,7 +131,7 @@ main()
 				_pip_dns="certbot-dns-${_dns}"
 				if [ "${_dns}" != "cloudflare" ]; then
 					echo "[INFO]: Installing certbot DNS plugin -> ${_dns}..."
-					pip install --timeout 60 --no-cache-dir "${_pip_dns}" || exit 2
+					pip install --timeout 60 --no-cache-dir --root-user-action ignore "${_pip_dns}" || exit 2
 					pip cache purge || exit 2
 					echo -e "[OK]: Done.\n"
 				fi
@@ -159,7 +159,7 @@ main()
 	done
 
 	echo "[INFO]: Upgrading certbot..."
-	pip install --timeout 60 --no-cache-dir --upgrade certbot || exit 2
+	pip install --timeout 60 --no-cache-dir --root-user-action ignore --upgrade certbot || exit 2
 	pip cache purge || exit 2
 	echo -e "[OK]: Done.\n"
 
@@ -174,7 +174,7 @@ main()
 
 	if [ ${_disable_renew} != true ]; then
 		echo "[INFO]: Adding cron jobs..."
-		echo -e "\n0 1 1 * * root /usr/local/bin/pip install --timeout 60 --no-cache-dir --upgrade certbot ${_pip_dns} >> /var/log/cron.pip.log 2>&1" >> /etc/crontab || exit 2
+		echo -e "\n0 1 1 * * root /usr/local/bin/pip install --timeout 60 --no-cache-dir --root-user-action ignore --upgrade certbot ${_pip_dns} >> /var/log/cron.pip.log 2>&1" >> /etc/crontab || exit 2
 		echo "0 2 * * 1 root /usr/local/bin/python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -n --keep --max-log-backups 10 --deploy-hook '/usr/local/bin/certbot-deploy-hook.sh' ${_certbot_staging} ${_certbot_renew} >> /var/log/cron.certbot.log 2>&1 && /usr/local/bin/certbot-permissions.sh" >> /etc/crontab || exit 2
 		echo -e "[OK]: Done.\n"
 


### PR DESCRIPTION
This pull request updates the `scripts/docker/docker-entrypoint.sh` script to include the `--root-user-action ignore` flag in all `pip install` commands. This change suppresses warnings when running `pip install` as the root user, improving script behavior in containerized environments.

### Updates to `pip install` commands:

* Added the `--root-user-action ignore` flag to the `pip install` command for installing Certbot DNS plugins, ensuring warnings about root user actions are suppressed. (`scripts/docker/docker-entrypoint.sh`, [scripts/docker/docker-entrypoint.shL134-R134](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L134-R134))
* Updated the `pip install` command for upgrading Certbot to include the `--root-user-action ignore` flag, maintaining consistency across all installations. (`scripts/docker/docker-entrypoint.sh`, [scripts/docker/docker-entrypoint.shL162-R162](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L162-R162))
* Modified the cron job entry to include the `--root-user-action ignore` flag in the `pip install` command for Certbot upgrades, ensuring the same behavior during scheduled updates. (`scripts/docker/docker-entrypoint.sh`, [scripts/docker/docker-entrypoint.shL177-R177](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L177-R177))